### PR TITLE
change pak download location on ubuntu-release

### DIFF
--- a/containers/ubuntu-release/Dockerfile
+++ b/containers/ubuntu-release/Dockerfile
@@ -51,7 +51,7 @@ RUN if [ "$(uname -p)" = "x86_64" ]; then \
 # Install pak
 
 RUN /opt/R/release/bin/R -q -e \
-    'install.packages("pak", repos = sprintf("https://r-lib.github.io/p/pak/%s/%s/%s/%s", "release", .Platform$pkgType, R.Version()$os, R.Version()$arch))'
+    'install.packages("pak", source = TRUE)'
 
 # ------------------------------------------------------------------------------------
 # Use user's package library for the rest


### PR DESCRIPTION
Hi all,

The current ubuntu-release images do not have pak installed as the pak github does not have a release subdirectory anymore. Figured it would make sense to get it from cran instead.