### PR TITLE
Small corrections to known flags

### DIFF
--- a/containers/gcc13/Dockerfile
+++ b/containers/gcc13/Dockerfile
@@ -91,7 +91,7 @@ ENV _R_CHECK_LIMIT_CORES_ true
 ENV _R_CHECK_LENGTH_1_CONDITION_ package:_R_CHECK_PACKAGE_NAME_,verbose
 #ENV _R_CHECK_LENGTH_1_LOGIC2_="package:_R_CHECK_PACKAGE_NAME_,verbose"
 ENV _R_S3_METHOD_LOOKUP_BASEENV_AFTER_GLOBALENV_ true
-ENV _R_CHECK_COMPILATION_FLAGS_KNOWN_="-Wno-deprecated-declarations -Wno-ignored-attributes -Wno-parentheses-Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Werror=implicit-function-declaration"
+ENV _R_CHECK_COMPILATION_FLAGS_KNOWN_="-Wno-deprecated-declarations -Wno-ignored-attributes -Wno-parentheses -Werror=format-security -Wp,-D_FORTIFY_SOURCE=3 -Werror=implicit-function-declaration"
 ENV _R_CHECK_AUTOCONF_ true
 ENV _R_CHECK_THINGS_IN_CHECK_DIR_ true
 ENV _R_CHECK_THINGS_IN_TEMP_DIR_ true


### PR DESCRIPTION
I [ran into this where I would get non-portable flag warnings](https://dev.azure.com/ursacomputing/crossbow/_build/results?buildId=63519&view=logs&j=0da5d1d9-276d-5173-c4c4-9d4d4ed14fdb&t=6c939d89-0d1a-51f2-8b30-091a7a82e98c) when adapting Arrow's CI to use the new containers 

The missing space is I believe a typo and the number on `FORTIFY_SOURCE` didn't match [what's in the builder](https://github.com/r-hub/containers/blob/5c56aa29ee4ec682080a2a0336177473423d9358/builder/config.ubuntu-2204-asan#L6) if I'm following the flow of those files.