### PR TITLE
Bump two GitHub Actions versions on gha website page

### DIFF
--- a/website/gha.qmd
+++ b/website/gha.qmd
@@ -25,7 +25,7 @@ jobs:
       image: ghcr.io/r-hub/containers/atlas:latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Install dependencies
       run: |
@@ -61,7 +61,7 @@ jobs:
       image: ghcr.io/r-hub/containers/${{ github.event.inputs.inpcont }}:latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Install dependencies
       run: |
         R -q -e 'pak::pkg_install(c("deps::.", "any::rcmdcheck"), dependencies = TRUE)'

--- a/website/gha.qmd
+++ b/website/gha.qmd
@@ -110,7 +110,7 @@ jobs:
       run: r-check
 
     - name: Upload check result as artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: check-results
         path: /check


### PR DESCRIPTION
I noticed these hadn't been updated.