### PR TITLE
Don't use `-fsanitize-trap`

### DIFF
--- a/containers/clang-asan/Dockerfile
+++ b/containers/clang-asan/Dockerfile
@@ -54,7 +54,7 @@ RUN curl -o /usr/local/bin/checkbashisms \
 # ------------------------------------------------------------------------------------
 # Update the system config, because the user Makevars is ignored
 # for some packages
-RUN app="-fsanitize=address,undefined -fno-sanitize=float-divide-by-zero -fno-sanitize=alignment -fno-omit-frame-pointer -fsanitize=pointer-overflow -fsanitize-trap=pointer-overflow -fsanitize=signed-integer-overflow"; \
+RUN app="-fsanitize=address,undefined -fno-sanitize=float-divide-by-zero -fno-sanitize=alignment -fno-omit-frame-pointer -fsanitize=pointer-overflow -fsanitize=signed-integer-overflow"; \
     appxx="$app -frtti"; \
     makeconf="/opt/R/devel-asan/lib/R/etc/Makeconf"; \
     sed -i -E '/^CC ?=/ s/$/ '"$app"/ "${makeconf}" && \


### PR DESCRIPTION
The `-fsanitize-trap` option turns diagnosable runtime errors into illegal instruction exceptions [[1](https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html#usage), [2](https://maskray.me/blog/2023-01-29-all-about-undefined-behavior-sanitizer#trap-mode)] which are much less informative without an interactive debugger (in a typical GitHub Action context). For example:

1. With default options, pointer arithmetic on a null pointer crashes the process without any diagnostic:
```
$ podman run --rm -it ghcr.io/r-hub/containers/clang-asan Rscript -e '
 writeLines("
  #include <stdlib.h>
  void repr(int * foo) {
   int * volatile bar = NULL;
   int * baz = &bar[0];
   if (*foo == 42) *foo = *baz; // do not give me 42
  }                                                 
 ", "repr.c")
 tools::Rcmd("SHLIB repr.c")
 dyn.load("repr.so")
 .C("repr", integer(1))
'
using C compiler: ‘Ubuntu clang version 19.1.7 (++20250114103320+cd708029e0b2-1~exp1~20250114103432.75)’
clang-19 -fsanitize=address,undefined -fno-sanitize=float-divide-by-zero -fno-sanitize=alignment -fno-omit-frame-pointer -fsanitize=pointer-overflow -fsanitize-trap=pointer-overflow -fsanitize=signed-integer-overflow -I"/opt/R/devel-asan/lib/R/include" -DNDEBUG   -I/usr/local/clang/include -I/usr/local/include    -fpic  -g -O3 -Wall -pedantic  -Wp,-D_FORTIFY_SOURCE=3  -c repr.c -o repr.o
clang-19 -fsanitize=address,undefined -fno-sanitize=float-divide-by-zero -fno-sanitize=alignment -fno-omit-frame-pointer -fsanitize=pointer-overflow -fsanitize-trap=pointer-overflow -fsanitize=signed-integer-overflow -shared -L/opt/R/devel-asan/lib/R/lib -L/usr/local/clang/lib -L/usr/local/lib -o repr.so repr.o -L/opt/R/devel-asan/lib/R/lib -lR

 *** caught illegal operation ***
address 0x7feb7fb0759a, cause 'illegal operand'

Traceback:
 1: .C("repr", integer(1))
An irrecoverable exception occurred. R is aborting now ...
```
Here, `SIGILL` is all we've got. Why'd my workflow crash?
2. If we remove the `-fsanitize-trap` argument, the error is still caught, but now we have the diagnostics we've came to UBsan for, and the process survives:
```
$ podman run --rm -it ghcr.io/r-hub/containers/clang-asan Rscript -e '
 system(r"{sed -i -e "s/-fsanitize-trap\S*//g" /opt/R/devel-asan/lib/R/etc/Makeconf}")
 writeLines("
  #include <stdlib.h>
  void repr(int * foo) {
   int * volatile bar = NULL;
   int * baz = &bar[0];
   if (*foo == 42) *foo = *baz; // do not give me 42
  }          
 ", "repr.c")
 tools::Rcmd("SHLIB repr.c")
 dyn.load("repr.so")
 .C("repr", integer(1))
'
using C compiler: ‘Ubuntu clang version 19.1.7 (++20250114103320+cd708029e0b2-1~exp1~20250114103432.75)’
clang-19 -fsanitize=address,undefined -fno-sanitize=float-divide-by-zero -fno-sanitize=alignment -fno-omit-frame-pointer -fsanitize=pointer-overflow  -fsanitize=signed-integer-overflow -I"/opt/R/devel-asan/lib/R/include" -DNDEBUG   -I/usr/local/clang/include -I/usr/local/include    -fpic  -g -O3 -Wall -pedantic  -Wp,-D_FORTIFY_SOURCE=3  -c repr.c -o repr.o
clang-19 -fsanitize=address,undefined -fno-sanitize=float-divide-by-zero -fno-sanitize=alignment -fno-omit-frame-pointer -fsanitize=pointer-overflow -fsanitize=signed-integer-overflow -shared -L/opt/R/devel-asan/lib/R/lib -L/usr/local/clang/lib -L/usr/local/lib -o repr.so repr.o -L/opt/R/devel-asan/lib/R/lib -lR
repr.c:5:17: runtime error: applying zero offset to null pointer
    #0 0x7effdac565d3 in repr /repr.c:5:17
    #1 0x7f006e2d9ea5 in do_dotCode /tmp/R-devel/src/main/dotcode.c:1963:2
    #2 0x7f006e30ab76 in Rf_eval /tmp/R-devel/src/main/eval.c:1260:9
    #3 0x7f006e35a721 in Rf_ReplIteration /tmp/R-devel/src/main/main.c:265:2
    #4 0x7f006e35bc9e in R_ReplConsole /tmp/R-devel/src/main/main.c:317:11
    #5 0x7f006e35bc9e in run_Rmainloop /tmp/R-devel/src/main/main.c:1219:5
    #6 0x7f006e35bd0a in Rf_mainloop /tmp/R-devel/src/main/main.c:1226:5
    #7 0x563b0c3fbf07 in main /tmp/R-devel/src/main/Rmain.c:29:5
    #8 0x7f006dd74d8f  (/usr/lib/x86_64-linux-gnu/libc.so.6+0x29d8f) (BuildId: 490fef8403240c91833978d494d39e537409b92e)
    #9 0x7f006dd74e3f in __libc_start_main (/usr/lib/x86_64-linux-gnu/libc.so.6+0x29e3f) (BuildId: 490fef8403240c91833978d494d39e537409b92e)
    #10 0x563b0c31a354 in _start (/opt/R/devel-asan/lib/R/bin/exec/R+0x2c354) (BuildId: ff82bc7c98c181240e9a80ccd227fb032965c6c4)

SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior repr.c:5:17 
[[1]]
[1] 0
```