### PR TITLE
Target clang 20

### DIFF
--- a/containers/clang20/Dockerfile
+++ b/containers/clang20/Dockerfile
@@ -85,9 +85,9 @@ RUN curl -o /usr/local/bin/checkbashisms \
 RUN export DEBIAN_FRONTEND=noninteractive && \
     apt-get update -y && \
     apt-get install -y gnupg && \
-    echo "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy main" \
+    echo "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-20 main" \
          > /etc/apt/sources.list.d/llvm.list && \
-    echo "deb-src http://apt.llvm.org/jammy/ llvm-toolchain-jammy main" \
+    echo "deb-src http://apt.llvm.org/jammy/ llvm-toolchain-jammy-20 main" \
          >> /etc/apt/sources.list.d/llvm.list && \
     curl -L https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
     apt-get update -y && \


### PR DESCRIPTION
Clang 20 is no longer the snapshot, but is now at `llvm-toolchain-jammy-20` (with the snapshot being clang-21). I suspect this coincided with the release candidate of clang 20. I built this locally and the image did succeed to build.