### PR TITLE
Set RHUB repo as ubuntu-24.04 for s390x

### DIFF
--- a/containers/s390x/Dockerfile
+++ b/containers/s390x/Dockerfile
@@ -8,7 +8,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
     apt-get clean
 
 # Use R-hub repo
-RUN echo "options(repos = c(RHUB = 'https://raw.githubusercontent.com/r-hub/repos/main/ubuntu-22.04-s390x/4.3', getOption('repos')))" \
+RUN echo "options(repos = c(RHUB = 'https://raw.githubusercontent.com/r-hub/repos/main/ubuntu-24.04-s390x/4.3', getOption('repos')))" \
       >> /usr/lib/R/library/base/R/Rprofile
 
 # System requirements that pak does not know about


### PR DESCRIPTION
I see the `r-hub/repos` repo has:

- [ubuntu-22.04-s390x/4.1](https://github.com/r-hub/repos/tree/main/ubuntu-22.04-s390x/4.1)
- [ubuntu-24.04-s390x/4.3](https://github.com/r-hub/repos/tree/main/ubuntu-24.04-s390x/4.3)

But when I try to run the s390x workflow, it is actually looking for https://raw.githubusercontent.com/r-hub/repos/main/ubuntu-22.04-s390x/4.3
