### PR TITLE
rchk: fix 'R CMD config' parsing

### DIFF
--- a/builder/rchk.sh
+++ b/builder/rchk.sh
@@ -12,11 +12,11 @@ LD=clang++ -stdlib=libc++
 EOF
 
 /opt/R/devel-rchk/bin/R CMD config --all |
-    grep 'CXX[0-9]* +=' |
+    grep 'CXX[0-9]*\s*=' |
     sed 's/clang/wllvm/g' >> "$MAKEVARS"
 
 /opt/R/devel-rchk/bin/R CMD config --all |
-    grep 'CC[0-9]* +=' |
+    grep 'CC[0-9]*\s*=' |
     sed 's/clang/wllvm/g' >> "$MAKEVARS"
 
 export R_MAKEVARS_USER="$MAKEVARS"


### PR DESCRIPTION
Fixes #96

Since https://github.com/wch/r-source/commit/cf588ba6151d4c6cbecf5b4b9e15e6302b1d53f8, on R-devel `R CMD config --all` now ends like this:

```text
## The following variables are defunct
CPP CXXCPP CXX11 CXX11STD CXX11FLAGS CXX11PICFLAGS CXX14 CXX14STD CXX14FLAGS CXX14PICFLAGS SHLIB_CXX11LD SHLIB_CXX11LDFLAGS SHLIB_CXX14LD SHLIB_CXX14LDFLAGS
```

This PR modifies a script here that parses that output, to ignore that line and therefore avoid creating a malformed Makevars.

## Notes for Reviewers

### How I tested this

Tried with a package that has C and C++ code.

```shell
docker run \
    --rm \
    --platform linux/amd64 \
    -it ghcr.io/r-hub/containers/rchk:latest \
    bash

mkdir -p /tmp/packages
cd /tmp/packages
curl -O https://cran.r-project.org/src/contrib/lightgbm_4.6.0.tar.gz
Rscript -e "install.packages(c('R6', 'jsonlite', 'data.table'), repos = 'https://cran.r-project.org')"
r-check $(pwd)
```

On the latest image pulled from GHCR, that fails in the way described on #96. Manually applying this patch to `/opt/R/devel-rchk/bin/rchk.sh`, it succeeds.

Thanks for your time and consideration.